### PR TITLE
Ability to specify hints that should be run using @SuppressWarnings keys.

### DIFF
--- a/cmdline/maven/src/main/java/org/netbeans/modules/jackpot30/maven/ListHints.java
+++ b/cmdline/maven/src/main/java/org/netbeans/modules/jackpot30/maven/ListHints.java
@@ -18,20 +18,15 @@
  */
 package org.netbeans.modules.jackpot30.maven;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
-import org.netbeans.modules.jackpot30.cmdline.Main;
 
 /**
- * @goal showgui
- * @author Jan Lahoda
+ * @goal list
  */
-public class ShowGuiJackpot30 extends AbstractMojo {
+public class ListHints extends RunJackpot30 {
 
     /**
      * @parameter property="project"
@@ -41,28 +36,9 @@ public class ShowGuiJackpot30 extends AbstractMojo {
     private MavenProject project;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
-        try {
-            if (!project.isExecutionRoot()) return;
+        if (!project.isExecutionRoot()) return;
 
-            String configurationFile = Utils.getJackpotConfigurationFile(project);
-
-            if (configurationFile == null)
-                throw new MojoExecutionException("No configuration file specified, cannot show configuration GUI");
-
-            List<String> cmdLine = new ArrayList<String>();
-
-            cmdLine.add("--config-file");
-            cmdLine.add(configurationFile);
-            cmdLine.addAll(RunJackpot30.sourceAndCompileClassPaths(project.getCollectedProjects()));
-            cmdLine.add("--show-gui");
-            System.err.println(cmdLine);
-
-            Main.compile(cmdLine.toArray(new String[0]));
-        } catch (IOException ex) {
-            throw new MojoExecutionException(ex.getMessage(), ex);
-        } catch (ClassNotFoundException ex) {
-            throw new MojoExecutionException(ex.getMessage(), ex);
-        }
+        runWithArguments(List.of("--list"));
     }
 
 }

--- a/cmdline/maven/src/main/java/org/netbeans/modules/jackpot30/maven/RunJackpot30.java
+++ b/cmdline/maven/src/main/java/org/netbeans/modules/jackpot30/maven/RunJackpot30.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.jackpot30.maven;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -40,75 +39,88 @@ import org.netbeans.modules.jackpot30.cmdline.Main;
 public abstract class RunJackpot30 extends AbstractMojo {
 
     protected final void doRun(MavenProject project, boolean apply) throws MojoExecutionException, MojoFailureException {
+        String sourceLevel = "1.5";
+        Xpp3Dom sourceLevelConfiguration = Utils.getPluginConfiguration(project, "org.apache.maven.plugins", "maven-compiler-plugin");
+
+        if (sourceLevelConfiguration != null) {
+            Xpp3Dom source = sourceLevelConfiguration.getChild("source");
+
+            if (source != null) {
+                sourceLevel = source.getValue();
+            }
+        }
+
+        String hint = Utils.getJackpotHint(project);
+        String configurationFile = Utils.getJackpotConfigurationFile(project);
+        boolean failOnWarnings = Utils.getJackpotFailOnWarnings(project);
+
+        List<String> cmdLine = new ArrayList<String>();
+
+        if (apply)
+            cmdLine.add("--apply");
+        else
+            cmdLine.add("--no-apply");
+
+        cmdLine.addAll(sourceAndCompileClassPaths(Collections.singletonList(project)));
+        cmdLine.add("--source");
+        cmdLine.add(sourceLevel);
+
+        if (hint != null) {
+            cmdLine.add("--hint");
+            cmdLine.add(hint);
+        }
+
+        if (configurationFile != null) {
+            cmdLine.add("--config-file");
+            cmdLine.add(configurationFile);
+        }
+
+        if (failOnWarnings) {
+            cmdLine.add("--fail-on-warnings");
+        }
+
+        boolean hasSourceRoots = false;
+
+        for (String sr : (List<String>) project.getCompileSourceRoots()) {
+            if (!hasSourceRoots && new File(sr).isDirectory()) {
+                hasSourceRoots = true;
+            }
+            cmdLine.add(sr);
+        }
+
+        if (!hasSourceRoots) {
+            getLog().debug("jackpot30 analyze: Not source roots to operate on");
+            return ;
+        }
+        runWithArguments(cmdLine);
+    }
+
+    protected final void runWithArguments(List<String> jackpotToolArguments) throws MojoExecutionException{
         try {
-            String sourceLevel = "1.5";
-            Xpp3Dom sourceLevelConfiguration = Utils.getPluginConfiguration(project, "org.apache.maven.plugins", "maven-compiler-plugin");
-
-            if (sourceLevelConfiguration != null) {
-                Xpp3Dom source = sourceLevelConfiguration.getChild("source");
-
-                if (source != null) {
-                    sourceLevel = source.getValue();
-                }
-            }
-
-            String configurationFile = Utils.getJackpotConfigurationFile(project);
-            boolean failOnWarnings = Utils.getJackpotFailOnWarnings(project);
-
-            List<String> cmdLine = new ArrayList<String>();
-
-            if (apply)
-                cmdLine.add("--apply");
-            else
-                cmdLine.add("--no-apply");
-
-            cmdLine.addAll(sourceAndCompileClassPaths(Collections.singletonList(project)));
-            cmdLine.add("--source");
-            cmdLine.add(sourceLevel);
-
-            if (configurationFile != null) {
-                cmdLine.add("--config-file");
-                cmdLine.add(configurationFile);
-            }
-
-            if (failOnWarnings) {
-                cmdLine.add("--fail-on-warnings");
-            }
-
-            boolean hasSourceRoots = false;
-
-            for (String sr : (List<String>) project.getCompileSourceRoots()) {
-                if (!hasSourceRoots && new File(sr).isDirectory()) {
-                    hasSourceRoots = true;
-                }
-                cmdLine.add(sr);
-            }
-
-            if (!hasSourceRoots) {
-                getLog().debug("jackpot30 analyze: Not source roots to operate on");
-                return ;
-            }
-
             Path bin = Paths.get(System.getProperty("java.home"))
                             .resolve("bin");
             Path launcher = bin.resolve("java");
+
             if (!Files.exists(launcher)) {
                 launcher = bin.resolve("java.exe");
             }
+
+            List<String> cmdLine = new ArrayList<>();
+
             cmdLine.addAll(0, Arrays.asList(launcher.toAbsolutePath().toString(),
                                             "-classpath", Main.class.getProtectionDomain().getCodeSource().getLocation().getPath(),
                                             "-XX:+IgnoreUnrecognizedVMOptions",
                                             "--add-opens=java.base/java.net=ALL-UNNAMED",
                                             "--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
                                             Main.class.getCanonicalName()));
+            cmdLine.addAll(jackpotToolArguments);
+
             if (new ProcessBuilder(cmdLine).inheritIO().start().waitFor() != 0) {
                 throw new MojoExecutionException("jackpo30 failed.");
             }
         } catch (IOException ex) {
             throw new MojoExecutionException(ex.getMessage(), ex);
         } catch (InterruptedException ex) {
-            throw new MojoExecutionException(ex.getMessage(), ex);
-        } catch (DependencyResolutionRequiredException ex) {
             throw new MojoExecutionException(ex.getMessage(), ex);
         }
     }
@@ -125,23 +137,27 @@ public abstract class RunJackpot30 extends AbstractMojo {
     }
 
     @SuppressWarnings("unchecked")
-    public static List<String> sourceAndCompileClassPaths(Iterable<? extends MavenProject> projects) throws DependencyResolutionRequiredException {
-        List<String> compileSourceRoots = new ArrayList<String>();
-        List<String> compileClassPath = new ArrayList<String>();
+    public static List<String> sourceAndCompileClassPaths(Iterable<? extends MavenProject> projects) throws MojoExecutionException {
+        try {
+            List<String> compileSourceRoots = new ArrayList<String>();
+            List<String> compileClassPath = new ArrayList<String>();
 
-        for (MavenProject project : projects) {
-            compileSourceRoots.addAll((List<String>) project.getCompileSourceRoots());
+            for (MavenProject project : projects) {
+                compileSourceRoots.addAll((List<String>) project.getCompileSourceRoots());
 
-            for (Resource r : (List<Resource>) project.getResources()) {
-                compileSourceRoots.add(r.getDirectory());
+                for (Resource r : (List<Resource>) project.getResources()) {
+                    compileSourceRoots.add(r.getDirectory());
+                }
+
+                compileClassPath.addAll((List<String>) project.getCompileClasspathElements());
             }
-            
-            compileClassPath.addAll((List<String>) project.getCompileClasspathElements());
-        }
 
-        return Arrays.asList("--sourcepath",
-                             toClassPathString(compileSourceRoots),
-                             "--classpath",
-                             toClassPathString(compileClassPath));
+            return Arrays.asList("--sourcepath",
+                                 toClassPathString(compileSourceRoots),
+                                 "--classpath",
+                                 toClassPathString(compileClassPath));
+        } catch (DependencyResolutionRequiredException ex) {
+            throw new MojoExecutionException(ex.getMessage(), ex);
+        }
     }
 }

--- a/cmdline/maven/src/main/java/org/netbeans/modules/jackpot30/maven/Utils.java
+++ b/cmdline/maven/src/main/java/org/netbeans/modules/jackpot30/maven/Utils.java
@@ -60,6 +60,20 @@ public class Utils {
         return null;
     }
 
+    public static String getJackpotHint(MavenProject project) {
+        Xpp3Dom configuration = getJackpotPluginConfiguration(project);
+
+        if (configuration != null) {
+            Xpp3Dom configurationFileElement = configuration.getChild("hint");
+
+            if (configurationFileElement != null) {
+                return configurationFileElement.getValue();
+            }
+        }
+
+        return null;
+    }
+
     public static boolean getJackpotFailOnWarnings(MavenProject project) {
         Xpp3Dom configuration = getJackpotPluginConfiguration(project);
 

--- a/cmdline/maven/tests/hint-option/golden
+++ b/cmdline/maven/tests/hint-option/golden
@@ -1,0 +1,12 @@
+${basedir}/src/main/java/test/App.java:24: warning: [Usage_of_Collection_Map_size_equals_0] java.util.Arrays.asList(args).size() == 0 can be replaced with java.util.Arrays.asList(args).isEmpty()
+        boolean b = java.util.Arrays.asList(args).size() == 0;
+                    ^
+[ERROR] Failed to execute goal org.apache.netbeans.modules.jackpot30:jackpot30-maven-plugin:20.0:analyze (default-cli) on project maven-test: jackpo30 failed. -> [Help 1]
+[ERROR] 
+[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+[ERROR] Re-run Maven using the -X switch to enable full debug logging.
+[ERROR] 
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
+
+result: 1

--- a/cmdline/maven/tests/hint-option/pom.xml
+++ b/cmdline/maven/tests/hint-option/pom.xml
@@ -1,0 +1,64 @@
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.netbeans.modules.jackpot30</groupId>
+  <artifactId>maven-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>jackpot30-maven-plugin-test1</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.netbeans.modules.jackpot30</groupId>
+        <artifactId>jackpot30-maven-plugin</artifactId>
+        <version>${jackpot.plugin.version}</version>
+        <configuration>
+             <hint>SizeReplaceableByIsEmpty</hint>
+             <failOnWarnings>true</failOnWarnings>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+            <source>17</source>
+            <target>17</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/cmdline/maven/tests/hint-option/src/main/java/test/App.java
+++ b/cmdline/maven/tests/hint-option/src/main/java/test/App.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package test;
+
+public class App  {
+
+    public static void main( String[] args ) {
+        boolean b = java.util.Arrays.asList(args).size() == 0;
+    }
+}

--- a/cmdline/tool/test/unit/src/org/netbeans/modules/jackpot30/cmdline/MainTest.java
+++ b/cmdline/tool/test/unit/src/org/netbeans/modules/jackpot30/cmdline/MainTest.java
@@ -1064,6 +1064,31 @@ public class MainTest extends NbTestCase {
                       "--source", "17");
     }
 
+    public void testRunBySuppressWarningsKeys() throws Exception {
+        String code =
+            "package test;\n" +
+            "public class Test {\n" +
+            "    private void test(java.util.Collection c) {\n" +
+            "        boolean b = c.size() == 0;\n" +
+            "        assert b = true;\n" +
+            "    }\n" +
+            "}\n";
+
+        doRunCompiler(code,
+                      "${workdir}/src/test/Test.java:4: warning: [Usage_of_Collection_Map_size_equals_0] c.size() == 0 can be replaced with c.isEmpty()\n" +
+                      "        boolean b = c.size() == 0;\n" +
+                      "                    ^\n" +
+                      "${workdir}/src/test/Test.java:5: warning: [Assert_with_side_effects] Assert condition produces side effects\n" +
+                      "        assert b = true;\n" +
+                      "               ^\n",
+                      "",
+                      "src/test/Test.java",
+                      code,
+                      null,
+                      "--hint",
+                      "SizeReplaceableByIsEmpty, AssertWithSideEffects");
+    }
+
     private static final String DONT_APPEND_PATH = new String("DONT_APPEND_PATH");
     private static final String IGNORE = new String("IGNORE");
 


### PR DESCRIPTION
There is an existing option for the Jackpot tool to specify a hint on the command line, but it accepts the display name of a single hint. This proposes to enhance the option with an ability to use the key for `@SuppressWarnings` when specifying a hint, and to provide multiple such keys to select multiple hints.

Also adds:
- shows the suppress warnings keys when listing hints,
- support for the option to the Maven plugin,
- support for `jackpot30:list` to the Maven plugin, so that one can list the hints using `mvn jackpot30:list`.
