### PR TITLE
Fixing download of JDK 25 GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,13 +46,7 @@ jobs:
       - name: Set up Ubuntu dependencies
         run: |
             sudo apt update
-            sudo apt install openjdk-17-jdk openjdk-21-jdk
-
-      - name: Set up latest JDK 25 from jdk.java.net
-        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
-        with:
-            website: jdk.java.net
-            release: 25
+            sudo apt install openjdk-17-jdk openjdk-21-jdk openjdk-25-jdk
 
       - name: Set up NetBeans
         run: |


### PR DESCRIPTION
`oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b` no longer supports JDK 25, but the distribution does, so using the distribution JDK feels like a sensible middle ground.